### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Package Publish
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]
@@ -44,6 +47,8 @@ jobs:
     if: false
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -68,6 +73,8 @@ jobs:
     if: "!contains(github.ref, '-')"
     needs: [publish-npm]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Potential fix for [https://github.com/roddolf/jsonld-sorter/security/code-scanning/8](https://github.com/roddolf/jsonld-sorter/security/code-scanning/8)

In general, fix this by explicitly specifying `permissions` for the `GITHUB_TOKEN` at either the workflow root or per job, granting only the scopes needed (likely `contents: read` for this simple CI workflow). This both documents intended access and prevents accidental escalation if repository defaults are broader.

For this specific workflow in `.github/workflows/ci.yml`, the best minimal change is to add a `permissions` block at the top level (so it applies to all jobs) with `contents: read`. That’s sufficient for `actions/checkout` and for typical Codecov usage, and it avoids any write permission to the repository. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 3 and before line 5). No imports or other definitions are needed since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
