### PR TITLE
fix: correct repository metadata and migrate to npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -34,12 +37,12 @@ jobs:
       - run: npm run build:src
       - name: Publish latest
         if: "!contains(github.ref, '-')"
-        run: npm publish --tag latest
+        run: npm publish --provenance --tag latest
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish next
         if: contains(github.ref, '-')
-        run: npm publish --tag next
+        run: npm publish --provenance --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,40 +37,10 @@ jobs:
       - run: npm run build:src
       - name: Publish latest
         if: "!contains(github.ref, '-')"
-        run: npm publish --provenance --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Publish next
-        if: contains(github.ref, '-')
-        run: npm publish --provenance --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  publish-gpr:
-    if: false
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          registry-url: https://npm.pkg.github.com/
-          scope: "@roddolf"
-      - run: npm ci
-      - run: npm run build:src
-      - name: Publish latest
-        if: "!contains(github.ref, '-')"
         run: npm publish --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Publish next
         if: contains(github.ref, '-')
         run: npm publish --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   publish-docs:
     if: "!contains(github.ref, '-')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,19 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+All notable changes to this project will be documented in this file.
 
 ### [0.2.4](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.4) (2022-10-14)
 
-
 ### Bug Fixes
 
-* **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sort/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
-* node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
+- **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sort/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
+- node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
 ### [0.2.3](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.3) (2022-10-14)
 
-
 ### Bug Fixes
 
-* node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
+- node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
 ### [0.2.2](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.2) (2022-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
-### [0.2.4](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.4) (2022-10-14)
+### [0.2.4](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.4) (2022-10-14)
 
 
 ### Bug Fixes
 
-* **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sort/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
-* node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
+* **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sorter/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
+* node version in publish action ([#39](https://github.com/roddolf/jsonld-sorter/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sorter/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
-### [0.2.3](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.3) (2022-10-14)
+### [0.2.3](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.3) (2022-10-14)
 
 
 ### Bug Fixes
 
-* node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
+* node version in publish action ([#39](https://github.com/roddolf/jsonld-sorter/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sorter/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
-### [0.2.2](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.2) (2022-10-14)
+### [0.2.2](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.2) (2022-10-14)
 
-### [0.2.1](https://github.com/roddolf/jsonld-sort/compare/v0.2.0...v0.2.1) (2019-10-23)
+### [0.2.1](https://github.com/roddolf/jsonld-sorter/compare/v0.2.0...v0.2.1) (2019-10-23)
 
-### [0.2.1-beta.1](https://github.com/roddolf/jsonld-sort/compare/v0.2.1-beta.0...v0.2.1-beta.1) (2019-10-23)
+### [0.2.1-beta.1](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1-beta.0...v0.2.1-beta.1) (2019-10-23)
 
-### [0.2.1-beta.0](https://github.com/roddolf/jsonld-sort/compare/v0.2.0...v0.2.1-beta.0) (2019-10-22)
+### [0.2.1-beta.0](https://github.com/roddolf/jsonld-sorter/compare/v0.2.0...v0.2.1-beta.0) (2019-10-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ### [0.2.4](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.4) (2022-10-14)
 
+
 ### Bug Fixes
 
-- **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sort/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
-- node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
+* **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sort/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
+* node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
 ### [0.2.3](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.3) (2022-10-14)
 
+
 ### Bug Fixes
 
-- node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
+* node version in publish action ([#39](https://github.com/roddolf/jsonld-sort/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sort/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
 ### [0.2.2](https://github.com/roddolf/jsonld-sort/compare/v0.2.1...v0.2.2) (2022-10-14)
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 
 Sort JSON-LD objects comparing by `@id` or `@value` if exists.
 
-**Support**: Node.js 16.x and above
+**Support**: Node.js 20.x and above

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/roddolf/jsonld-sort.git"
+    "url": "git+https://github.com/roddolf/jsonld-sorter.git"
   },
   "keywords": [
     "jsonld",
@@ -35,9 +35,9 @@
   "author": "Rodolfo Aguirre <aguirreg.rodolfo@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/roddolf/jsonld-sort/issues"
+    "url": "https://github.com/roddolf/jsonld-sorter/issues"
   },
-  "homepage": "https://github.com/roddolf/jsonld-sort#readme",
+  "homepage": "https://github.com/roddolf/jsonld-sorter#readme",
   "devDependencies": {
     "@tsconfig/node20": "^20.1.9",
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

- Fix Node.js version in README: `16.x` → `20.x` (matches `engines` field and CI matrix)
- Fix repository, bugs, and homepage URLs in `package.json`: `jsonld-sort` → `jsonld-sorter`
- Remove stale `standard-version` reference from CHANGELOG header
- Migrate npm publish to OIDC trusted publishing (removes `NPM_TOKEN` dependency, provenance is automatic)
- Remove disabled `publish-gpr` job

These changes require a release to propagate the corrected metadata to npm and GitHub Pages.