### PR TITLE
fix: pin Node 22.14 for trusted publishing, fix bin field and changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: "22.14"
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build:src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,42 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.6](https://github.com/roddolf/jsonld-sorter/compare/v0.2.5...v0.2.6) (2026-03-28)
-
+## [0.2.6](https://github.com/roddolf/jsonld-sorter/compare/v0.2.4...v0.2.6) (2026-03-28)
 
 ### Bug Fixes
 
 * combine release-please and publish into single workflow ([#131](https://github.com/roddolf/jsonld-sorter/issues/131)) ([73428b6](https://github.com/roddolf/jsonld-sorter/commit/73428b6ea1d6dc28b1cced9838c3c2abcd464662))
 * correct repository metadata and migrate to npm trusted publishing ([#129](https://github.com/roddolf/jsonld-sorter/issues/129)) ([2b11714](https://github.com/roddolf/jsonld-sorter/commit/2b117147e60d084da2438da69bc73f0b9b0e54ed))
-* **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sorter/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
-* node version in publish action ([#39](https://github.com/roddolf/jsonld-sorter/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sorter/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
-## [0.2.5](https://github.com/roddolf/jsonld-sorter/compare/v0.2.4...v0.2.5) (2026-03-28)
-
-
-### Bug Fixes
-
-* correct repository metadata and migrate to npm trusted publishing ([#129](https://github.com/roddolf/jsonld-sorter/issues/129)) ([2b11714](https://github.com/roddolf/jsonld-sorter/commit/2b117147e60d084da2438da69bc73f0b9b0e54ed))
-
-### [0.2.4](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.4) (2022-10-14)
-
+## [0.2.4](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.4) (2022-10-14)
 
 ### Bug Fixes
 
 * **docs:** update gh pages action ([0e35b27](https://github.com/roddolf/jsonld-sorter/commit/0e35b2702238330eeb0b9a4d1ef83852a2b90f50))
 * node version in publish action ([#39](https://github.com/roddolf/jsonld-sorter/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sorter/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
-### [0.2.3](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.3) (2022-10-14)
-
+## [0.2.3](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.3) (2022-10-14)
 
 ### Bug Fixes
 
 * node version in publish action ([#39](https://github.com/roddolf/jsonld-sorter/issues/39)) ([8155ab1](https://github.com/roddolf/jsonld-sorter/commit/8155ab14b66908c5c08bf824436b53e7ad785080))
 
-### [0.2.2](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.2) (2022-10-14)
+## [0.2.2](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1...v0.2.2) (2022-10-14)
 
-### [0.2.1](https://github.com/roddolf/jsonld-sorter/compare/v0.2.0...v0.2.1) (2019-10-23)
+## [0.2.1](https://github.com/roddolf/jsonld-sorter/compare/v0.2.0...v0.2.1) (2019-10-23)
 
-### [0.2.1-beta.1](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1-beta.0...v0.2.1-beta.1) (2019-10-23)
+## [0.2.1-beta.1](https://github.com/roddolf/jsonld-sorter/compare/v0.2.1-beta.0...v0.2.1-beta.1) (2019-10-23)
 
-### [0.2.1-beta.0](https://github.com/roddolf/jsonld-sorter/compare/v0.2.0...v0.2.1-beta.0) (2019-10-22)
+## [0.2.1-beta.0](https://github.com/roddolf/jsonld-sorter/compare/v0.2.0...v0.2.1-beta.0) (2019-10-22)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "bin": "dist/cli.js",
+  "bin": {
+    "jsonld-sorter": "dist/cli.js"
+  },
   "scripts": {
     "build": "npm-run-all build:*",
     "build:src": "tsup",


### PR DESCRIPTION
## Summary

- Pin `node-version` to `22.14` in the publish-npm job to meet the minimum requirement for npm trusted publishing (Node >= 22.14.0 / npm >= 11.5.1). The previous `node-version: 22` could resolve to a version below 22.14.0, which caused the v0.2.6 publish to fail with a 404 error.
- Fix `bin` field in `package.json` from shorthand string to explicit object (`{ "jsonld-sorter": "dist/cli.js" }`) to eliminate the npm auto-correction warning during publish.
- Clean up `CHANGELOG.md`:
  - Remove two stale entries from 0.2.6 that belonged to 0.2.4 (`docs: update gh pages action`, `node version in publish action`)
  - Remove the 0.2.5 section (release was deleted, never published to npm)
  - Update 0.2.6 compare link from `v0.2.5...v0.2.6` to `v0.2.4...v0.2.6`
  - Normalize old version headers from `###` (standard-version) to `##` (release-please)
  - Remove extra blank lines