### PR TITLE
fix: use Node 24 for publish job to get npm >= 11.5.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "22.14"
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build:src


### PR DESCRIPTION
## Summary

- Switch `node-version` from `22.14` to `24` in the `publish-npm` job.

## Root cause

The v0.2.7 publish failed with `E404 Not Found` because npm trusted publishing requires **npm CLI >= 11.5.1**, but Node 22.14.0 ships with **npm 10.9.2**. npm 11.x is a separate major version that only ships with Node 24.x.

This matches the [official npm docs example](https://docs.npmjs.com/trusted-publishers#github-actions-configuration) which uses `node-version: '24'`.

**Note:** The `publish-docs` job keeps `node-version: 22` since it doesn't interact with the npm registry.